### PR TITLE
16-bit Spritemoves

### DIFF
--- a/spritedata.asm
+++ b/spritedata.asm
@@ -29,36 +29,42 @@ stx spriteindex
 jsr get_xm  // xm for 0 in a
 
 get_xm:
+        php
         jsr getspritebase       // Get spritebase in .A
 		clc						// Clear the carry flag
         adc #xm                 // Add index to get fieldaddr
         jmp get_val
 
 get_xl:
+        php
         jsr getspritebase       // Get spritebase in .A
 		clc						// Clear the carry flag
         adc #xl                 // Add index to get fieldaddr
         jmp get_val
 
 get_ym:
+        php
         jsr getspritebase       // Get spritebase in .A
 		clc						// Clear the carry flag
         adc #ym                 // Add index to get fieldaddr
         jmp get_val
 
 get_yl:
+        php
         jsr getspritebase       // Get spritebase in .A
 		clc						// Clear the carry flag
         adc #yl                 // Add index to get fieldaddr
         jmp get_val
 
 get_xa:
+        php
         jsr getspritebase       // Get spritebase in .A
 		clc						// Clear the carry flag
         adc #xa                 // Add index to get fieldaddr
         jmp get_val
 
 get_ya:
+        php
         jsr getspritebase       // Get spritebase in .A
 		clc						// Clear the carry flag
         adc #ya                 // Add index to get fieldaddr
@@ -68,9 +74,11 @@ get_ya:
 get_val:
         tax                     // .A -> .X
         lda spritemem,x        // load fieldaddr -> .A
+        plp
         rts
 
 store_xm:
+        php
         pha
         jsr getspritebase       // Get spritebase in .A
 		clc						// Clear the carry flag
@@ -78,6 +86,7 @@ store_xm:
         jmp store_val
 
 store_xl:
+        php
         pha
         jsr getspritebase       // Get spritebase in .A
 		clc
@@ -85,6 +94,7 @@ store_xl:
         jmp store_val
 
 store_ym:
+        php
         pha
         jsr getspritebase       // Get spritebase in .A
 		clc
@@ -92,6 +102,7 @@ store_ym:
         jmp store_val
 
 store_yl:
+        php
         pha
         jsr getspritebase       // Get spritebase in .A
 		clc
@@ -99,6 +110,7 @@ store_yl:
         jmp store_val
 
 store_xa:
+        php
         pha
         jsr getspritebase       // Get spritebase in .A
 		clc
@@ -106,6 +118,7 @@ store_xa:
         jmp store_val
 
 store_ya:
+        php
         pha
         jsr getspritebase       // Get spritebase in .A
 		clc
@@ -115,6 +128,7 @@ store_ya:
 store_val:
         tax                     // .A -> .X
         pla
+        plp
         sta spritemem,x        // load fieldaddr -> .A
         rts
 

--- a/spritelib.asm
+++ b/spritelib.asm
@@ -93,16 +93,10 @@ left:
 	sec					// Clear the borrow flag
 	sbc #$01			// move left
 	jsr store_xl
-	cmp #$ff
-	beq left_dec_msb	// Increment MSB	
-	jsr left_edge
-rts	
-
-left_dec_msb:
 	jsr get_xm
-	sec					// Clear the borrow flagg
-	sbc #$01			// Add 1 to MSB
+	sbc #$00			// Subtract zero and borrow from lsb subtraction
 	jsr store_xm
+	jsr left_edge
 rts
 
 vertical:
@@ -118,8 +112,9 @@ right:
 	clc							// Clear the carry flag
 	adc #$01
 	jsr store_xl
-	cmp #$00
-	beq right_inc_msb
+	jsr get_xm
+	adc #$00					// Add zero and carry from lsb addition
+	jsr store_xm
 	jsr right_edge
 rts	
 
@@ -154,14 +149,6 @@ rts
 change_to_down:
 	lda #$00
 	jsr store_ya
-rts
-
-
-right_inc_msb:
-	jsr get_xm
-	clc							// Clear the carry register
-	adc #$1						// Add 1 to MSB
-	jsr store_xm
 rts
 
 right_edge:


### PR DESCRIPTION
* Preserve the processor flags during spritememory calculations (to keep carry and borrow during 16-bit calculations)
* Use 16-bit arithmetics to move sprites left and right. (up and down are not crossing the 8-bit boundary)
